### PR TITLE
changed gps source time zone to pdt, added test case, formatting

### DIFF
--- a/R/gps_file_reader.R
+++ b/R/gps_file_reader.R
@@ -50,8 +50,5 @@ seattle_baseline_1_gps_file_reader <- function (gps_file_path) {
   ## drop na rows (e.g. 3703 row of ~/Desktop/retrieved_backup/epiProject/walk_bout/data/trac/gps/gps_12015817_baseline_1.csv)
   gps_data <- drop_na(gps_data)
 
-  # moving this from main script to happen within this function [LBW 11/12: not sure why this is needed, to do: investigate]
-  gps_data <- gps_data[!(gps_data$subject_id %in% c("13421835_baseline_1", "12915257_baseline_1")), ]
-
   return(gps_data)
 }

--- a/R/gps_file_reader.R
+++ b/R/gps_file_reader.R
@@ -40,7 +40,7 @@ seattle_baseline_1_gps_file_reader <- function (gps_file_path) {
     stop("Unknown date format")
   }
   date_time_string_vector <- paste(input_df$date, input_df$time)
-  source_time_zone <- "UTC"
+  source_time_zone <- "America/Los_Angeles"
   target_time_zone <- "America/Los_Angeles"
   date_time <- with_tz(as.POSIXct(date_time_string_vector, format=date_time_format, tz=source_time_zone), tzone = target_time_zone)
 
@@ -49,6 +49,9 @@ seattle_baseline_1_gps_file_reader <- function (gps_file_path) {
 
   ## drop na rows (e.g. 3703 row of ~/Desktop/retrieved_backup/epiProject/walk_bout/data/trac/gps/gps_12015817_baseline_1.csv)
   gps_data <- drop_na(gps_data)
+
+  # moving this from main script to happen within this function [LBW 11/12: not sure why this is needed, to do: investigate]
+  gps_data <- gps_data[!(gps_data$subject_id %in% c("13421835_baseline_1", "12915257_baseline_1")), ]
 
   return(gps_data)
 }

--- a/R/process_many_subject.R
+++ b/R/process_many_subject.R
@@ -12,14 +12,18 @@ process_many_subject <- function (vector_of_acc_file_path=NULL, vector_of_gps_fi
   list_of_processed_result <- list()
   failed_subjects <- c()
   failed_messages <- c()
-  for (i in seq_along(vector_of_acc_file_path)) {
+for (i in seq_along(vector_of_acc_file_path)) {
     acc_file_path <- vector_of_acc_file_path[i]
     gps_file_path <- vector_of_gps_file_path[i]
     subject_id <- vector_of_subject_id[i]
     print(paste("Processing", vector_of_acc_file_path[i], vector_of_gps_file_path[i]))
     print(paste("Progress:", i, "of", length(vector_of_acc_file_path), "acc/gps pairs"))
 
-    processed_result <- process_one_subject(acc_file_path = acc_file_path, gps_file_path = gps_file_path, acc_file_reader = acc_file_reader, gps_file_reader = gps_file_reader, time_zone = time_zone)
+    processed_result <- process_one_subject(acc_file_path = acc_file_path,
+                                            gps_file_path = gps_file_path,
+                                            acc_file_reader = acc_file_reader,
+                                            gps_file_reader = gps_file_reader,
+                                            time_zone = time_zone)
     if (nrow(processed_result) == 0) {
       failed_subjects <- c(failed_subjects, subject_id)
       failed_messages <- c(failed_messages, colnames(processed_result)[ncol(processed_result)])
@@ -32,7 +36,8 @@ process_many_subject <- function (vector_of_acc_file_path=NULL, vector_of_gps_fi
     list_of_processed_result[[i]] <- processed_result
   }
 
-  print(tibble('failed_subject'=failed_subjects, 'message'=failed_messages) %>% arrange(message))
+
+  if(length(failed_subjects)>0){print(tibble('failed_subject'=failed_subjects, 'message'=failed_messages) %>% arrange(message))}
 
   # rbind and return
   summary_table <- do.call(rbind, list_of_processed_result)
@@ -109,3 +114,4 @@ get_paths <- function (accelerometry_phase2, gps_phase2) {
 
   return(path_all)
 }
+

--- a/R/subject_file_mapper.R
+++ b/R/subject_file_mapper.R
@@ -70,6 +70,8 @@ seattle_baseline_1_file_mapper <- function (acc_folder_path='/Users/wzhou87/Desk
   print(sprintf("Number of ACC subjects with no GPS mapping: %d", nrow(acc_unmatched_df)))
   print(sprintf("Number of GPS subjects with no ACC mapping: %d", nrow(gps_unmatched_df)))
   print(sprintf("Number of matched subjects: %d", nrow(valid_subject_file_mapping_df)))
+  # moving this from main script to happen within this function [LBW 11/12: not sure why this is needed, to do: investigate]
+  valid_subject_file_mapping_df <- valid_subject_file_mapping_df[!(valid_subject_file_mapping_df$subject_id %in% c("13421835_baseline_1", "12915257_baseline_1")), ]
 
   return(valid_subject_file_mapping_df)
 }

--- a/analysis/analyze_all_subject_seattle.R
+++ b/analysis/analyze_all_subject_seattle.R
@@ -1,15 +1,28 @@
 source("setup.R")
+library("measurements")
 
 ## configs
-acc_folder_path <- '/Users/wzhou87/Desktop/retrieved_backup/epiProject/walk_bout/data/trac/acc/'
-gps_folder_path <- '/Users/wzhou87/Desktop/retrieved_backup/epiProject/walk_bout/data/trac/gps/'
-result_save_folder <- "/Users/wzhou87/Desktop/retrieved_backup/epiProject/walk_bout/data/result/test/trac"
 time_zone <- 'America/Los_Angeles'
+acc_folder_path <- '/projects/trac/data/acc'
+gps_folder_path <- '/projects/trac/data/gps'
+result_save_folder <- "~/walkbout_results/test/trac" # TO DO: Make results directory if it doesn't exist
+
 
 ## 1. process all subjects and store the result
+# pull file paths:
 file_mapper_result <- seattle_baseline_1_file_mapper(acc_folder_path=acc_folder_path, gps_folder_path=gps_folder_path)
-file_mapper_result <- file_mapper_result[!(file_mapper_result$subject_id %in% c("13421835_baseline_1", "12915257_baseline_1")), ]  # epoch period 1min subjects
-path_result <- process_many_subject(vector_of_acc_file_path = file_mapper_result$acc_file_path, vector_of_gps_file_path = file_mapper_result$gps_file_path, vector_of_subject_id = file_mapper_result$subject_id, acc_file_reader = seattle_baseline_1_acc_file_reader, gps_file_reader = seattle_baseline_1_gps_file_reader, result_save_folder=result_save_folder, time_zone=time_zone)
+# for testing:
+subject_subset <- c()
+# subject_subset <- c("10100052_baseline_1", "14832802_baseline_1", "10100590_baseline_1")
+if(length(subject_subset)>0){file_mapper_result <- file_mapper_result[file_mapper_result$subject_id %in% subject_subset,]}
+# run walkbout code:
+path_result <- process_many_subject(vector_of_acc_file_path = file_mapper_result$acc_file_path,
+                                    vector_of_gps_file_path = file_mapper_result$gps_file_path,
+                                    vector_of_subject_id = file_mapper_result$subject_id,
+                                    acc_file_reader = seattle_baseline_1_acc_file_reader,
+                                    gps_file_reader = seattle_baseline_1_gps_file_reader,
+                                    result_save_folder=result_save_folder,
+                                    time_zone=time_zone)
 
 
 ## 2. read the processed results, do analysis and output summary


### PR DESCRIPTION
I have tracked down the time zone information and it looks like what was happening is that the code was assuming the source (raw data) time zone was UTC and therefore converting it to PDT. In actuality, it looks like all data (acc and gps) is coming in in PDT time zone. So, when I change the source time zone to be PDT and the desired time zone to be PDT, no changes are made, and the dataset merge happens cleanly. The resulting bouts are close but not precisely what Phil found. Here is a summary of (1) where I am: 
1.	Script: gps_file_reader.R, Function: seattle_baseline_1_gps_file_reader 
In line 43: Changed from UTC to America/Los Angeles
Change: source_time_zone <- “America/Los_Angeles” 

The walk bouts are somewhat similar but not exactly the same. There are two issues: (i) the walkbouts that do appear to match up in date/time are not exact matches in date/time/speed but are within 10-35 minutes or so of each other, and generally within 1 kmh of each other (approximately). The other issue is (ii) some walk bouts that Phil finds are not in the rwalkbout output and vice versa. Additionally, there is some mismatch in the value for walk1_gps.